### PR TITLE
Jasan/ip only

### DIFF
--- a/postwhite
+++ b/postwhite
@@ -127,11 +127,11 @@ function normalize_ipv4() {
 
 # Create host query function
 function query_host() {
-	"${spftoolspath}"/despf.sh "$1" >> "${tmp1}"
+	"${spftoolspath}"/despf.sh "$1" | grep ^ip >> "${tmp1}"
 }
 
 function query_black_host() {
-	"${spftoolspath}"/despf.sh "$1" >> "${blktmp1}"
+	"${spftoolspath}"/despf.sh "$1" | grep ^ip >> "${blktmp1}"
 }
 
 # Create progress dots function

--- a/postwhite
+++ b/postwhite
@@ -3,8 +3,8 @@
 # Postwhite - Automatic Postcreen Whitelist / Blacklist Generator
 #
 # By Steve Jenkins (http://stevejenkins.com/)
-	version="1.36"
-	lastupdated="07 January 2017"
+	version="1.37"
+	lastupdated="10 January 2017"
 #
 # Usage: place entire postwhite directory in /usr/local/bin then 
 # run ./postwhite
@@ -50,7 +50,7 @@ social_hosts="facebook.com twitter.com pinterest.com instagram.com tumblr.com re
 
 commerce_hosts="craigslist.org amazon.com ebay.com paypal.com"
 
-bulk_hosts="sendgrid.com sendgrid.net mailchimp.com exacttarget.com cust-spf.exacttarget.com constantcontact.com icontact.com mailgun.com fbmta.com mailjet.com"
+bulk_hosts="sendgrid.com sendgrid.net mailchimp.com exacttarget.com cust-spf.exacttarget.com constantcontact.com icontact.com mailgun.com fishbowl.com fbmta.com mailjet.com"
 
 misc_hosts="zendesk.com github.com"
 


### PR DESCRIPTION
This fixes #10 and jsarenik/spf-tools#118 by limiting the output of `despf.sh` to lines starting with `ip`.