### PR TITLE
Correcting argument processing

### DIFF
--- a/postwhite
+++ b/postwhite
@@ -56,10 +56,10 @@ set -e
 
 printf "Starting Postwhite v$version ($lastupdated)\n"
 
-if [ -n $2 ]; then
-	config_file="/etc/postwhite.conf"
+if [ -n "$1" ]; then
+	config_file="$1"
 else
-	config_file="$2"
+	config_file="/etc/postwhite.conf"
 fi
 
 # Read config file options


### PR DESCRIPTION
Passing in the path to the postwhite.conf per the examples in the docs ("./postwhite /path/to/config-file") wasn't working.  Have corrected the arg processing (should be $1 vs $2) and added some quotes since the test, '-n', is a string based test.

Tests now read: If $1 was passed in, use that, else use default path of /etc/postwhite.conf